### PR TITLE
Return EOF-Token instead of raise EOFError.

### DIFF
--- a/source/cssparser/parser.d
+++ b/source/cssparser/parser.d
@@ -157,3 +157,15 @@ unittest
   assert(token.tokenType == TokenType.Ident);
   assert(token.value == "bar");
 }
+
+
+// https://drafts.csswg.org/css-syntax/#typedef-eof-token
+unittest
+{
+  const s = "";
+  auto parser = new Parser(s);
+  auto token = parser.next;
+  assert(token.tokenType == TokenType.EOF);
+  token = parser.next;
+  assert(token.tokenType == TokenType.EOF);
+}

--- a/source/cssparser/tokenizer.d
+++ b/source/cssparser/tokenizer.d
@@ -10,18 +10,6 @@ import std.typecons : Tuple, tuple;
 import std.math : pow;
 
 
-class EOFError : Exception
-{
-  this(string message,
-       string file =__FILE__,
-       size_t line = __LINE__,
-       Throwable next = null) @safe pure nothrow
-  {
-    super(message, file, line, next);
-  }
-}
-
-
 enum TokenType
 {
   Ident,
@@ -56,6 +44,7 @@ enum TokenType
   CloseParenthesis,
   CloseSquareBracket,
   CloseCurlyBracket,
+  EOF,
 }
 
 
@@ -545,7 +534,7 @@ class Tokenizer
   Token nextToken()
   {
     if (isEOF) {
-      throw new EOFError("reached end-of-file.");
+      return Token(TokenType.EOF);
     }
     char c = nextChar;
 


### PR DESCRIPTION
Reference: https://drafts.csswg.org/css-syntax/#typedef-eof-token

It will suitable for css-syntax compatible.
